### PR TITLE
Make `require_login` redirect location configurable?

### DIFF
--- a/lib/monban/configuration.rb
+++ b/lib/monban/configuration.rb
@@ -1,6 +1,5 @@
 module Monban
   class Configuration
-
     attr_accessor :user_class, :user_token_field, :user_token_store_field
     attr_accessor :encryption_method, :token_comparison, :user_lookup_field
     attr_accessor :sign_in_notice
@@ -8,6 +7,7 @@ module Monban
     attr_accessor :authentication_service, :password_reset_service
     attr_accessor :failure_app
     attr_accessor :creation_method, :find_method
+    attr_accessor :require_login_redirect
 
     def initialize
       setup_class_defaults
@@ -59,6 +59,7 @@ module Monban
       @user_lookup_field = :email
       @creation_method = default_creation_method
       @find_method = default_find_method
+      @require_login_redirect = { controller: '/sessions', action: 'new' }
     end
 
     def setup_services
@@ -73,5 +74,4 @@ module Monban
       @failure_app = lambda{|e|[401, {"Content-Type" => "text/plain"}, ["Authorization Failed"]] }
     end
   end
-
 end

--- a/spec/monban/controller_helpers_spec.rb
+++ b/spec/monban/controller_helpers_spec.rb
@@ -16,7 +16,7 @@ module Monban
     end
 
     class Dummy
-      attr_reader :redirected, :flash, :request
+      attr_reader :redirected, :redirected_to, :flash, :request
       def initialize warden
         @warden = warden
         @flash = Flash.new
@@ -25,6 +25,7 @@ module Monban
       end
       def redirect_to path
         @redirected = true
+        @redirected_to = path
       end
       def env
         { "warden" => @warden }
@@ -139,6 +140,7 @@ module Monban
       @warden.should_receive(:user).and_return(false)
       @dummy.require_login
       expect(@dummy.redirected).to eq(true)
+      expect(@dummy.redirected_to).to eq(Monban.config.require_login_redirect)
       expect(@dummy.flash.notice).to eq(Monban.config.sign_in_notice)
     end
 


### PR DESCRIPTION
Currently:

``` ruby
def require_login
  unless signed_in?
    flash.notice = Monban.config.sign_in_notice
    redirect_to controller: '/sessions', action: 'new'
  end
end
```

This is an issue in "SuperMonban" because the controller is namespaced. Additionally, you might actually want to redirect to your sign up controller - particularly if your sessions are long-lived (it's more likely you are a new user than someone needing to sign in).

Perhaps a configurable string could be used if provided, but the current behavior would be the default?
