### PR TITLE
Use a configurable responder when not signed in

### DIFF
--- a/NEWS.rdoc
+++ b/NEWS.rdoc
@@ -1,3 +1,11 @@
+== HEAD
+* A configuration for `no_login_redirect` was added. This accepts anything that
+  can be passed to `redirect_to` and is used when `require_login` is called with
+  no logged in user.
+* A configuration for `no_login_handler` was added. This allows developers to
+  completely customize the response when `require_login` is called with no
+  logged in user.
+
 == 0.0.15
 * Delegate user_class correctly so that config returns class
 * Fixed issue authenticate session not allowing for multiple fields

--- a/lib/monban/configuration.rb
+++ b/lib/monban/configuration.rb
@@ -1,6 +1,5 @@
 module Monban
   class Configuration
-
     attr_accessor :user_token_field, :user_token_store_field
     attr_accessor :encryption_method, :token_comparison, :user_lookup_field
     attr_accessor :sign_in_notice
@@ -8,6 +7,7 @@ module Monban
     attr_accessor :authentication_service, :password_reset_service
     attr_accessor :failure_app
     attr_accessor :creation_method, :find_method
+    attr_accessor :no_login_handler, :no_login_redirect
 
     attr_writer :user_class
 
@@ -43,6 +43,13 @@ module Monban
       end
     end
 
+    def default_no_login_handler
+      ->(controller) do
+        controller.flash.notice = Monban.config.sign_in_notice
+        controller.redirect_to Monban.config.no_login_redirect
+      end
+    end
+
     def user_class
       @user_class.constantize
     end
@@ -65,6 +72,8 @@ module Monban
       @user_lookup_field = :email
       @creation_method = default_creation_method
       @find_method = default_find_method
+      @no_login_redirect = { controller: '/session', action: 'new' }
+      @no_login_handler = default_no_login_handler
     end
 
     def setup_services
@@ -79,5 +88,4 @@ module Monban
       @failure_app = lambda{|e|[401, {"Content-Type" => "text/plain"}, ["Authorization Failed"]] }
     end
   end
-
 end

--- a/lib/monban/controller_helpers.rb
+++ b/lib/monban/controller_helpers.rb
@@ -57,8 +57,7 @@ module Monban
 
     def require_login
       unless signed_in?
-        flash.notice = Monban.config.sign_in_notice
-        redirect_to controller: '/sessions', action: 'new'
+        Monban.config.no_login_handler.call(self)
       end
     end
   end

--- a/spec/monban/controller_helpers_spec.rb
+++ b/spec/monban/controller_helpers_spec.rb
@@ -16,7 +16,7 @@ module Monban
     end
 
     class Dummy
-      attr_reader :redirected, :flash, :request
+      attr_reader :redirected, :redirected_to, :flash, :request
       def initialize warden
         @warden = warden
         @flash = Flash.new
@@ -25,6 +25,7 @@ module Monban
       end
       def redirect_to path
         @redirected = true
+        @redirected_to = path
       end
       def env
         { "warden" => @warden }
@@ -139,6 +140,7 @@ module Monban
       @warden.should_receive(:user).and_return(false)
       @dummy.require_login
       expect(@dummy.redirected).to eq(true)
+      expect(@dummy.redirected_to).to eq(Monban.config.no_login_redirect)
       expect(@dummy.flash.notice).to eq(Monban.config.sign_in_notice)
     end
 


### PR DESCRIPTION
Use a configurable handler when not signed in

The aim here is to to give Monban users full control over what happens
when `requires_login` is run and a `User` is not signed in.
- Default redirect location configurable with `no_login_redirect`.
  This accepts anything that can be passed to `redirect_to`.
- A configuration for `no_login_handler` was added. This allows the
  developer to easily completely customize the response to account for
  MIME types or whatever they please.
