### PR TITLE
Handle nil `user_params`

### DIFF
--- a/lib/monban/services/sign_up.rb
+++ b/lib/monban/services/sign_up.rb
@@ -23,7 +23,7 @@ module Monban
 
       def token_digest(user_params)
         undigested_token = user_params[token_field]
-        unless undigested_token.empty?
+        unless undigested_token.blank?
           Monban.hash_token(undigested_token)
         end
       end

--- a/spec/monban/services/sign_up_spec.rb
+++ b/spec/monban/services/sign_up_spec.rb
@@ -36,4 +36,14 @@ describe Monban::Services::SignUp, '#perform' do
       expect(args[:password_digest]).to be_nil
     end
   end
+
+  it 'does not create a user with a nil password' do
+    allow(User).to receive(:create)
+    user_params = { email: nil, password: nil }
+
+    Monban::Services::SignUp.new(user_params).perform
+    expect(User).to have_received(:create) do |args|
+      expect(args[:password_digest]).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
When `SignUp.new({ email: nil, password: nil }).process` is invoked, things
blow up.

Unfortunately, `#empty?` only exists on `String`, not `NilClass`. Fortunately,
`NilClass#blank?` exists, and `String#blank?` is an alias for `String#empty?`.

It's a win-win!