### PR TITLE
Monban::Test::Helpers.sign_in return user

### DIFF
--- a/lib/monban/test/helpers.rb
+++ b/lib/monban/test/helpers.rb
@@ -8,8 +8,11 @@ module Monban
 
       # Sign a user in
       # @param user [User] user to sign in
+      # @returns user [User] signed in user
       def sign_in user
         login_as user
+
+        user
       end
 
       # Sign a user out

--- a/spec/monban/test_helpers_spec.rb
+++ b/spec/monban/test_helpers_spec.rb
@@ -64,7 +64,7 @@ module Monban
 
       it 'performs a sign in' do
         user = double(id: 1)
-        sign_in(user)
+        return_value = sign_in(user)
         app = lambda do |env|
           $captures << :run
           env['warden'].should be_authenticated
@@ -72,6 +72,8 @@ module Monban
           valid_response
         end
         setup_rack(app).call(env_with_params)
+
+        return_value.should eq(user)
         $captures.should eq([:run])
       end
 


### PR DESCRIPTION
Allows invocations following the pattern:

```ruby
user = sign_in(create(:user))
```