### PR TITLE
Replace `to_hash` with `to_h`

### DIFF
--- a/NEWS.rdoc
+++ b/NEWS.rdoc
@@ -1,3 +1,6 @@
+== master
+* Replace `to_hash` with `to_h`
+
 == 0.3.1
 * Extend private interface for services
 

--- a/lib/monban/services/sign_up.rb
+++ b/lib/monban/services/sign_up.rb
@@ -16,7 +16,7 @@ module Monban
       # Performs the service
       # @see Monban::Configuration.default_creation_method
       def perform
-        Monban.config.creation_method.call(user_params.to_hash)
+        Monban.config.creation_method.call(user_params.to_h)
       end
 
       private


### PR DESCRIPTION
`to_hash` returns unsafe parameters whereas `to_h` does not