### PR TITLE
Param transformer for sanitizing and normalizing

### DIFF
--- a/NEWS.rdoc
+++ b/NEWS.rdoc
@@ -1,5 +1,6 @@
 == master
 * Do not perform lookup if no params are passed to lookup
+* Add param transformer for sanitizing and normalizing
 
 == 0.3.1
 * Extend private interface for services

--- a/lib/monban.rb
+++ b/lib/monban.rb
@@ -8,6 +8,7 @@ require "monban/failure_app"
 require "monban/back_door"
 require "monban/warden_setup"
 require "monban/field_map"
+require "monban/param_transformer"
 require "monban/strategies/password_strategy"
 require "active_support/core_ext/module/attribute_accessors"
 

--- a/lib/monban/param_transformer.rb
+++ b/lib/monban/param_transformer.rb
@@ -1,0 +1,38 @@
+module Monban
+  # Parameter transformer. Sanitizes and transforms parameter values
+  # @since 1.0.0
+  class ParamTransformer
+    # Initialize parameter transformer
+    #
+    # @param params [ActionController::Parameters] parameters to be altered
+    def initialize(params, transformations)
+      @params = params
+      @transformations = transformations
+    end
+
+    # Returns the transformed parameters
+    def to_h
+      sanitized_params.each_with_object({}) do |(key, value), hash|
+        hash[key] = transform(key, value)
+      end
+    end
+
+    private
+
+    attr_reader :params, :transformations
+
+    def sanitized_params
+      params.to_h
+    end
+
+    def transform(key, value)
+      return value unless value.is_a? String
+
+      if transformations.key?(key)
+        transformations[key].call(value)
+      else
+        value
+      end
+    end
+  end
+end

--- a/lib/monban/services/sign_up.rb
+++ b/lib/monban/services/sign_up.rb
@@ -16,7 +16,7 @@ module Monban
       # Performs the service
       # @see Monban::Configuration.default_creation_method
       def perform
-        Monban.config.creation_method.call(user_params.to_hash)
+        Monban.config.creation_method.call(user_params)
       end
 
       private


### PR DESCRIPTION
Add a param transformer that sanitizes and normalizes parameters coming
in. Calls `to_h` on ActionController::Params to get a hash of permitted
parameters and then maps their keys against a configurable list in order
to determine if any transformations should happen.

Currently the only transformed param is email, which is downcased in
order to prevent case insensitivity prevent signing in or resetting
passwords.