### PR TITLE
Wrap helper_method calls in respond_to?(:helper_method)

### DIFF
--- a/lib/monban/controller_helpers.rb
+++ b/lib/monban/controller_helpers.rb
@@ -7,7 +7,9 @@ module Monban
   module ControllerHelpers
     extend ActiveSupport::Concern
     included do
-      helper_method :current_user, :signed_in?
+      if respond_to?(:helper_method)
+        helper_method :current_user, :signed_in?
+      end
     end
 
     # Sign in a user


### PR DESCRIPTION
Currently `Monban::ControllerHelpers` depends on `#helper_method`, which is defined inside `AbstractController::Helpers`. This module is included in `ActionController::Base`, but it is not included by default in `ActionController::Metal`. So it's not available in Ruby on Rails 5.0 applications in API mode (rails-api).

`#helper_method` is not essential to the functionality of the methods inside `Monban::ControllerHelpers`, so this PR wraps all `#helper_method` calls with `respond_to?(:helper_method)` checks.

See https://github.com/rails/rails/issues/21067 and https://github.com/plataformatec/devise/pull/3732 for reference.