### PR TITLE
Fix default finder bug for multiple lookup fields

### DIFF
--- a/lib/monban/configuration.rb
+++ b/lib/monban/configuration.rb
@@ -54,8 +54,7 @@ module Monban
     # @see Monban.config.user_class
     def default_find_method
       ->(params) do
-        updated_params = Monban.transform_params(params)
-        Monban.config.user_class.find_by(updated_params)
+        Monban.config.user_class.find_by(params)
       end
     end
 


### PR DESCRIPTION
When I use [the recommended code for authenticating users by username or password][example], I get an error in `default_find_method`.

With multiple lookup attributes (`email_or_password`), the find method gets called with `params == ["email = ? OR username = ?", "user_input", "user_input"]`. When we try to call `#to_h` on this three-element array, Ruby throws the error: 

```
TypeError in SessionsController#create
wrong element type String at 0 (expected array)
```

I was able to fix this in my code by overriding the find method:

```ruby
# config/initializers/monban.rb

Monban.configure do |config|
  config.find_method = ->(params) do
    Monban.config.user_class.find_by(params)
  end
end
```

There are likely other less invasive ways to solve this bug, but I'm submitting the solution that worked for me.

[example]: http://www.rubydoc.info/github/halogenandtoast/monban/Monban/ControllerHelpers#authenticate_session-instance_method