### PR TITLE
Add failing test for sign in with multiple attrs

### DIFF
--- a/lib/monban/configuration.rb
+++ b/lib/monban/configuration.rb
@@ -54,8 +54,7 @@ module Monban
     # @see Monban.config.user_class
     def default_find_method
       ->(params) do
-        updated_params = Monban.transform_params(params)
-        Monban.config.user_class.find_by(updated_params)
+        Monban.config.user_class.find_by(params)
       end
     end
 

--- a/spec/features/user/user_signs_in_spec.rb
+++ b/spec/features/user/user_signs_in_spec.rb
@@ -12,7 +12,7 @@ feature 'User signs in' do
     expect(current_path).to eq posts_path
   end
 
-  scenario 'with username or password' do
+  scenario 'with email or username' do
     user = User.create!(
       email: "example@example.com",
       password_digest: "password",

--- a/spec/features/user/user_signs_in_spec.rb
+++ b/spec/features/user/user_signs_in_spec.rb
@@ -11,4 +11,19 @@ feature 'User signs in' do
 
     expect(current_path).to eq posts_path
   end
+
+  scenario 'with username or password' do
+    user = User.create!(
+      email: "example@example.com",
+      password_digest: "password",
+      username: "example",
+    )
+
+    visit multiple_attributes_sign_in_path
+    fill_in "session_email_or_username", with: user.username
+    fill_in "session_password", with: 'password'
+    click_button 'go'
+
+    expect(current_path).to eq posts_path
+  end
 end

--- a/spec/rails_app/app/controllers/multiple_attributes_sessions_controller.rb
+++ b/spec/rails_app/app/controllers/multiple_attributes_sessions_controller.rb
@@ -1,0 +1,28 @@
+class MultipleAttributesSessionsController < ApplicationController
+  def new
+  end
+
+  def create
+    user = authenticate_session(
+      session_params,
+      email_or_username: [:email, :email_or_username],
+    )
+
+    if sign_in(user)
+      redirect_to posts_path
+    else
+      redirect_to root_path, notice: "Invalid email or password"
+    end
+  end
+
+  def destroy
+    sign_out
+    redirect_to root_path
+  end
+
+  private
+
+  def session_params
+    params.require(:session).permit(:email_or_username, :password)
+  end
+end

--- a/spec/rails_app/app/controllers/multiple_attributes_sessions_controller.rb
+++ b/spec/rails_app/app/controllers/multiple_attributes_sessions_controller.rb
@@ -5,7 +5,7 @@ class MultipleAttributesSessionsController < ApplicationController
   def create
     user = authenticate_session(
       session_params,
-      email_or_username: [:email, :email_or_username],
+      email_or_username: [:email, :username],
     )
 
     if sign_in(user)

--- a/spec/rails_app/app/models/user.rb
+++ b/spec/rails_app/app/models/user.rb
@@ -1,7 +1,7 @@
 require 'active_hash'
 class User < ActiveHash::Base
   include ActiveModel::Validations
-  attr_accessor :email, :password_digest, :password
+  attr_accessor :email, :password_digest, :password, :username
   validates :email, presence: true
 
   def self.find_by(params)

--- a/spec/rails_app/app/views/multiple_attributes_sessions/new.html.erb
+++ b/spec/rails_app/app/views/multiple_attributes_sessions/new.html.erb
@@ -1,0 +1,5 @@
+<%= form_for :session do |f| %>
+  <%= f.text_field :email_or_username %>
+  <%= f.text_field :password %>
+  <%= f.submit 'go' %>
+<% end %>

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -18,7 +18,12 @@ RailsApp::Application.routes.draw do
   post "sign_in" => "sessions#create"
   delete "sign_out" => "sessions#destroy"
   get "sign_up" => "users#new"
+
   get "invalid_sign_in" => "invalid_sessions#new"
   post "invalid_sign_in" => "invalid_sessions#create"
+
+  get "multiple_attributes_sign_in" => "multiple_attributes_sessions#new"
+  post "multiple_attributes_sign_in" => "multiple_attributes_sessions#create"
+
   get "basic_auth" => "basic_auth#show"
 end


### PR DESCRIPTION
This is a failing test case to reproduce the error referenced in #54. We should close that issue in favor of this one.

## Problem

The recommended implementation for sign in by email or username throws an error when looking up the User record.

Stack trace:
```
  1) User signs in with username or password
     Failure/Error: params.to_h

     TypeError:
       wrong element type String at 0 (expected array)
     # ./lib/monban/param_transformer.rb:25:in `to_h'
     # ./lib/monban/param_transformer.rb:25:in `sanitized_params'
     # ./lib/monban/param_transformer.rb:15:in `to_h'
     # ./lib/monban.rb:66:in `transform_params'
     # ./lib/monban/configuration.rb:57:in `block in default_find_method'
     # ./lib/monban.rb:90:in `lookup'
     # ./lib/monban/controller_helpers.rb:105:in `authenticate_session'
     # ./spec/rails_app/app/controllers/multiple_attributes_sessions_controller.rb:6:in `create'
     # ./lib/monban/back_door.rb:30:in `call'
     # ./spec/features/user/user_signs_in_spec.rb:25:in `block (2 levels) in <top (required)>'
```