### PR TITLE
Fix sign in with multiple fields

### DIFF
--- a/lib/oath/configuration.rb
+++ b/lib/oath/configuration.rb
@@ -54,8 +54,7 @@ module Oath
     # @see Oath.config.user_class
     def default_find_method
       ->(params) do
-        updated_params = Oath.transform_params(params)
-        Oath.config.user_class.find_by(updated_params)
+        Oath.config.user_class.find_by(params)
       end
     end
 

--- a/spec/features/user/user_signs_in_spec.rb
+++ b/spec/features/user/user_signs_in_spec.rb
@@ -18,6 +18,10 @@ feature 'User signs in' do
       password_digest: "password",
       username: "example",
     )
+    allow(User).to receive(:where).with({ id: user.id }).and_call_original
+    allow(User).to receive(:where).with(
+      ["email = ? OR username = ?", "example", "example"]
+    ).and_return([user])
 
     visit multiple_attributes_sign_in_path
     fill_in "session_email_or_username", with: user.username

--- a/spec/features/user/user_signs_in_spec.rb
+++ b/spec/features/user/user_signs_in_spec.rb
@@ -12,7 +12,7 @@ feature 'User signs in' do
     expect(current_path).to eq posts_path
   end
 
-  scenario 'with username or password' do
+  scenario 'with email or username' do
     user = User.create!(
       email: "example@example.com",
       password_digest: "password",

--- a/spec/features/user/user_signs_in_spec.rb
+++ b/spec/features/user/user_signs_in_spec.rb
@@ -11,4 +11,19 @@ feature 'User signs in' do
 
     expect(current_path).to eq posts_path
   end
+
+  scenario 'with username or password' do
+    user = User.create!(
+      email: "example@example.com",
+      password_digest: "password",
+      username: "example",
+    )
+
+    visit multiple_attributes_sign_in_path
+    fill_in "session_email_or_username", with: user.username
+    fill_in "session_password", with: 'password'
+    click_button 'go'
+
+    expect(current_path).to eq posts_path
+  end
 end

--- a/spec/rails_app/app/controllers/multiple_attributes_sessions_controller.rb
+++ b/spec/rails_app/app/controllers/multiple_attributes_sessions_controller.rb
@@ -1,0 +1,28 @@
+class MultipleAttributesSessionsController < ApplicationController
+  def new
+  end
+
+  def create
+    user = authenticate_session(
+      session_params,
+      email_or_username: [:email, :email_or_username],
+    )
+
+    if sign_in(user)
+      redirect_to posts_path
+    else
+      redirect_to root_path, notice: "Invalid email or password"
+    end
+  end
+
+  def destroy
+    sign_out
+    redirect_to root_path
+  end
+
+  private
+
+  def session_params
+    params.require(:session).permit(:email_or_username, :password)
+  end
+end

--- a/spec/rails_app/app/controllers/multiple_attributes_sessions_controller.rb
+++ b/spec/rails_app/app/controllers/multiple_attributes_sessions_controller.rb
@@ -5,7 +5,7 @@ class MultipleAttributesSessionsController < ApplicationController
   def create
     user = authenticate_session(
       session_params,
-      email_or_username: [:email, :email_or_username],
+      email_or_username: [:email, :username],
     )
 
     if sign_in(user)

--- a/spec/rails_app/app/models/user.rb
+++ b/spec/rails_app/app/models/user.rb
@@ -1,7 +1,7 @@
 require 'active_hash'
 class User < ActiveHash::Base
   include ActiveModel::Validations
-  attr_accessor :email, :password_digest, :password
+  attr_accessor :email, :password_digest, :password, :username
   validates :email, presence: true
 
   def self.find_by(params)

--- a/spec/rails_app/app/views/multiple_attributes_sessions/new.html.erb
+++ b/spec/rails_app/app/views/multiple_attributes_sessions/new.html.erb
@@ -1,0 +1,5 @@
+<%= form_for :session do |f| %>
+  <%= f.text_field :email_or_username %>
+  <%= f.text_field :password %>
+  <%= f.submit 'go' %>
+<% end %>

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -18,7 +18,12 @@ RailsApp::Application.routes.draw do
   post "sign_in" => "sessions#create"
   delete "sign_out" => "sessions#destroy"
   get "sign_up" => "users#new"
+
   get "invalid_sign_in" => "invalid_sessions#new"
   post "invalid_sign_in" => "invalid_sessions#create"
+
+  get "multiple_attributes_sign_in" => "multiple_attributes_sessions#new"
+  post "multiple_attributes_sign_in" => "multiple_attributes_sessions#create"
+
   get "basic_auth" => "basic_auth#show"
 end


### PR DESCRIPTION
Hi Matt, 

I was teaching a friend Rails and using Oath for authentication solution (of course). But I found the multiple fields auth does not work right now. There is already a solution in #55. I update his work so you could merge and release a new version of Oath.

> can you just do a small write up about your solution. I assume the problem is that the params were being transformed twice. Was that the case?
>  -- halogenandtoast on https://github.com/halogenandtoast/oath/pull/55#issuecomment-261141234

Sign in with multiple fields:

```ruby
# SessionsController
def create
  user = authenticate_session(session_params, email_or_username: [:email, :username])
end
```

In `authenticate_session` (`L103`) we already transformed the params https://github.com/halogenandtoast/oath/blob/f850ea5122d37285f0377675b9c084942086280f/lib/oath/controller_helpers.rb#L101-L107 

and in `Oath.lookup`'s `self.config.find_method` https://github.com/halogenandtoast/oath/blob/f850ea5122d37285f0377675b9c084942086280f/lib/oath.rb#L86-L91

which calls `Oath::Configuration#default_method` that tries to transform again https://github.com/halogenandtoast/oath/blob/f850ea5122d37285f0377675b9c084942086280f/lib/oath/configuration.rb#L55-L60

hence raises this error:

```
TypeError in SessionsController#create
wrong element type String at 0 (expected array)
```

The fix was not transformed twice.

cc @gracewashere Closes #55 